### PR TITLE
Fix issue to retain directory structure of initially placed file

### DIFF
--- a/python/lsst/ctrl/oods/fileIngester.py
+++ b/python/lsst/ctrl/oods/fileIngester.py
@@ -80,7 +80,6 @@ class FileIngester(object):
         """ Route the message to the proper handler
         """
         msg_type = body['MSG_TYPE']
-        LOGGER.info("TEMP: received message {body}")
         ch.basic_ack(method.delivery_tag)
         if msg_type in self._msg_actions:
             handler = self._msg_actions.get(msg_type)
@@ -97,20 +96,26 @@ class FileIngester(object):
         else:
             return f"{str(e.__cause__)};  {cause}"
 
-    def create_bad_dirname(self, directory, original):
+    def create_bad_dirname(self, bad_dir_root, staging_dir_root, original):
         # strip the original directory location, except for the date
-        newfile = original.lstrip(self.forwarder_staging_dir)
+        newfile = self.strip_prefix(original, staging_dir_root)
 
-        # split into date and filename
+        # split into subdir and filename
         head, tail = os.path.split(newfile)
 
         # create subdirectory path name for directory with date
-        newdir = os.path.join(directory, head)
+        newdir = os.path.join(bad_dir_root, head)
 
         # create the directory, and hand the name back
         os.makedirs(newdir, exist_ok=True)
 
         return newdir
+
+    def strip_prefix(self, name, prefix):
+        ret = name
+        if name.startswith(prefix):
+            ret = name[len(prefix):].lstrip('/')
+        return ret
 
     def create_link_to_file(self, filename, dirname):
         """Create a link from filename to a new file in directory dirname
@@ -122,12 +127,11 @@ class FileIngester(object):
         dirname : `str`
             Directory where new link will be located
         """
-        print(f"self.forwarder_staging_dir = {self.forwarder_staging_dir}")
-        print(f"filename = {filename}")
-        print(f"dirname = {dirname}")
-        # remove the staging area portion from the filepath
-        basefile = filename.replace(self.forwarder_staging_dir, '').lstrip('/')
-        print(f"basefile = {basefile}")
+        # remove the staging area portion from the filepath; note that
+        # we don't use os.path.basename here because the file might be
+        # in a subdirectory of the staging directory.  We want to retain
+        #  that subdirectory name
+        basefile = self.strip_prefix(filename, self.forwarder_staging_dir)
 
         # create a new full path to where the file will be linked for the OODS
         new_file = os.path.join(dirname, basefile)
@@ -143,11 +147,21 @@ class FileIngester(object):
         return new_file
 
     def stageFiles(self, msg):
+        """ stage the files to their butler staging areas
+        and remove the original file
+        """
         filename = os.path.realpath(msg['FILENAME'])
 
-        for butlerProxy in self.butlers:
-            local_staging_dir = butlerProxy.getStagingDirectory()
-            self.create_link_to_file(filename, local_staging_dir)
+        try:
+            for butlerProxy in self.butlers:
+                local_staging_dir = butlerProxy.getStagingDirectory()
+                self.create_link_to_file(filename, local_staging_dir)
+        except Exception:
+            LOGGER.info(f"error staging files butler for {filename}")
+            return
+        # file has been linked to all staging areas;
+        # now we unlink the original file.
+        os.unlink(filename)
 
     async def ingest(self, msg):
 
@@ -176,10 +190,16 @@ class FileIngester(object):
             d['DESCRIPTION'] = description
             await self.publisher.publish_message(self.PUBLISH_QUEUE, d)
 
+    def get_locally_staged_filename(self, butlerProxy, full_filename):
+        basefile = self.strip_prefix(full_filename, self.forwarder_staging_dir)
+        local_staging_dir = butlerProxy.getStagingDirectory()
+        locally_staged_filename = os.path.join(local_staging_dir, basefile)
+        return locally_staged_filename
+
     def ingest_file(self, butlerProxy, msg):
         camera = msg['CAMERA']
         obsid = msg['OBSID']
-        filename = os.path.realpath(msg['FILENAME'])
+        filename = self.get_locally_staged_filename(butlerProxy, os.path.realpath(msg['FILENAME']))
         archiver = msg['ARCHIVER']
 
         try:
@@ -191,8 +211,9 @@ class FileIngester(object):
             status_msg = f"{butler.getName()}: {filename} could not be ingested: {self.extract_cause(e)}"
             LOGGER.exception(status_msg)
             bad_dir = butlerProxy.getBadFileDirectory()
+            staging_dir = butlerProxy.getStagingDirectory()
 
-            bad_file_dir = self.create_bad_dirname(bad_dir, filename)
+            bad_file_dir = self.create_bad_dirname(bad_dir, staging_dir, filename)
             try:
                 LOGGER.info(f"Moving {filename} to {bad_file_dir}")
                 shutil.move(filename, bad_file_dir)

--- a/python/lsst/ctrl/oods/fileIngester.py
+++ b/python/lsst/ctrl/oods/fileIngester.py
@@ -24,6 +24,7 @@ import logging
 import shutil
 import os
 import os.path
+from pathlib import PurePath
 from lsst.ctrl.oods.butlerProxy import ButlerProxy
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.dm.csc.base.consumer import Consumer
@@ -112,9 +113,8 @@ class FileIngester(object):
         return newdir
 
     def strip_prefix(self, name, prefix):
-        ret = name
-        if name.startswith(prefix):
-            ret = name[len(prefix):].lstrip('/')
+        p = PurePath(name)
+        ret = str(p.relative_to(prefix))
         return ret
 
     def create_link_to_file(self, filename, dirname):

--- a/tests/test_gen2.py
+++ b/tests/test_gen2.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import tempfile
+from pathlib import PurePath
 from shutil import copyfile
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -66,9 +67,8 @@ class Gen2TestCase(asynctest.TestCase):
         return config
 
     def strip_prefix(self, name, prefix):
-        ret = name
-        if name.startswith(prefix):
-            ret = name[len(prefix):].lstrip('/')
+        p = PurePath(name)
+        ret = str(p.relative_to(prefix))
         return ret
 
     async def testATIngest(self):

--- a/tests/test_gen2.py
+++ b/tests/test_gen2.py
@@ -41,33 +41,39 @@ class Gen2TestCase(asynctest.TestCase):
             config = yaml.safe_load(f)
 
         ingesterConfig = config["ingester"]
-        dataDir = tempfile.mkdtemp()
-        ingesterConfig["forwarderStagingDirectory"] = dataDir
+        self.forwarderStagingDirectory = tempfile.mkdtemp()
+        ingesterConfig["forwarderStagingDirectory"] = self.forwarderStagingDirectory
 
-        badDir = tempfile.mkdtemp()
         butlerConfig = config["ingester"]["butlers"][0]["butler"]
-        butlerConfig["badFileDirectory"] = badDir
 
-        butlerStageDir = tempfile.mkdtemp()
-        butlerConfig["stagingDirectory"] = butlerStageDir
+        self.badDir = tempfile.mkdtemp()
+        butlerConfig["badFileDirectory"] = self.badDir
 
-        repoDir = tempfile.mkdtemp()
-        butlerConfig["repoDirectory"] = repoDir
+        self.stagingRootDir = tempfile.mkdtemp()
+        butlerConfig["stagingDirectory"] = self.stagingRootDir
 
-        destFile = os.path.join(dataDir, fits_name)
-        copyfile(fitsFile, destFile)
+        self.repoDir = tempfile.mkdtemp()
+        butlerConfig["repoDirectory"] = self.repoDir
 
-        mapperFileName = os.path.join(repoDir, "_mapper")
+        subDir = tempfile.mkdtemp(dir=self.forwarderStagingDirectory)
+        self.destFile = os.path.join(subDir, fits_name)
+        copyfile(fitsFile, self.destFile)
+
+        mapperFileName = os.path.join(self.repoDir, "_mapper")
         with open(mapperFileName, 'w') as mapper_file:
             mapper_file.write(mapper)
 
-        return config, destFile, repoDir, badDir
+        return config
+
+    def strip_prefix(self, name, prefix):
+        ret = name
+        if name.startswith(prefix):
+            ret = name[len(prefix):].lstrip('/')
+        return ret
 
     async def testATIngest(self):
         fits_name = "2020032700020-det000.fits.fz"
-        config, destFile, repoDir, badDir = self.createConfig("ingest_gen2.yaml",
-                                                              fits_name,
-                                                              "lsst.obs.lsst.latiss.LatissMapper")
+        config = self.createConfig("ingest_gen2.yaml", fits_name, "lsst.obs.lsst.latiss.LatissMapper")
 
         ingesterConfig = config["ingester"]
         forwarder_staging_dir = ingesterConfig["forwarderStagingDirectory"]
@@ -80,21 +86,20 @@ class Gen2TestCase(asynctest.TestCase):
         msg = {}
         msg['CAMERA'] = "LATISS"
         msg['OBSID'] = "AT_C_20180920_000028"
-        msg['FILENAME'] = destFile
+        msg['FILENAME'] = self.destFile
         msg['ARCHIVER'] = "AT"
         await ingester.ingest(msg)
 
         files = scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
-        bad_path = os.path.join(badDir, fits_name)
+        name = self.strip_prefix(self.destFile, forwarder_staging_dir)
+        bad_path = os.path.join(self.badDir, name)
         self.assertFalse(os.path.exists(bad_path))
 
     async def testCCIngest(self):
         fits_name = "3019053000001-R22-S00-det000.fits.fz"
-        config, destFile, repoDir, badDir = self.createConfig("ingest_gen2.yaml",
-                                                              fits_name,
-                                                              "lsst.obs.lsst.comCam.LsstComCamMapper")
+        config = self.createConfig("ingest_gen2.yaml", fits_name, "lsst.obs.lsst.comCam.LsstComCamMapper")
 
         ingesterConfig = config["ingester"]
         forwarder_staging_dir = ingesterConfig["forwarderStagingDirectory"]
@@ -107,21 +112,20 @@ class Gen2TestCase(asynctest.TestCase):
         msg = {}
         msg['CAMERA'] = "COMCAM"
         msg['OBSID'] = "CC_C_20190530_000001"
-        msg['FILENAME'] = destFile
+        msg['FILENAME'] = self.destFile
         msg['ARCHIVER'] = "CC"
         await ingester.ingest(msg)
 
         files = scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
-        bad_path = os.path.join(badDir, fits_name)
+        name = self.strip_prefix(self.destFile, forwarder_staging_dir)
+        bad_path = os.path.join(self.badDir, name)
         self.assertFalse(os.path.exists(bad_path))
 
     async def testBadIngest(self):
         fits_name = "bad.fits.fz"
-        config, destFile, repoDir, badDir = self.createConfig("ingest_gen2.yaml",
-                                                              fits_name,
-                                                              "lsst.obs.lsst.comCam.LsstComCamMapper")
+        config = self.createConfig("ingest_gen2.yaml", fits_name, "lsst.obs.lsst.comCam.LsstComCamMapper")
 
         ingesterConfig = config["ingester"]
         forwarder_staging_dir = ingesterConfig["forwarderStagingDirectory"]
@@ -134,14 +138,15 @@ class Gen2TestCase(asynctest.TestCase):
         msg = {}
         msg['CAMERA'] = "COMCAM"
         msg['OBSID'] = "CC_C_20190530_000001"
-        msg['FILENAME'] = destFile
+        msg['FILENAME'] = self.destFile
         msg['ARCHIVER'] = "CC"
         await ingester.ingest(msg)
 
         files = scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
-        bad_path = os.path.join(badDir, fits_name)
+        name = self.strip_prefix(self.destFile, forwarder_staging_dir)
+        bad_path = os.path.join(self.badDir, name)
         self.assertTrue(os.path.exists(bad_path))
 
 

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import tempfile
+from pathlib import PurePath
 from shutil import copyfile
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -59,9 +60,8 @@ class Gen3ComCamIngesterTestCase(asynctest.TestCase):
         return config
 
     def strip_prefix(self, name, prefix):
-        ret = name
-        if name.startswith(prefix):
-            ret = name[len(prefix):].lstrip('/')
+        p = PurePath(name)
+        ret = str(p.relative_to(prefix))
         return ret
 
     async def testAuxTelIngest(self):

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -46,13 +46,13 @@ class MultiComCamIngesterTestCase(asynctest.TestCase):
 
         for x in ingesterConfig["butlers"]:
             butlerConfig = x["butler"]
-            print(f"butlerConfig = {butlerConfig}")
+
             butlerConfig["badFileDirectory"] = tempfile.mkdtemp()
-            print(f"badFileDirectory for {butlerConfig} is {butlerConfig['badFileDirectory']}")
+
             butlerConfig["stagingDirectory"] = tempfile.mkdtemp()
-            print(f"stagingDirectory for {butlerConfig} is {butlerConfig['stagingDirectory']}")
+
             repoDir = tempfile.mkdtemp()
-            print(f"repoDir for {butlerConfig} is {repoDir}")
+
             butlerConfig["repoDirectory"] = repoDir
             if butlerConfig["class"]["import"] == "lsst.ctrl.oods.gen2ButlerIngester":
                 mapperFileName = os.path.join(repoDir, "_mapper")
@@ -61,7 +61,7 @@ class MultiComCamIngesterTestCase(asynctest.TestCase):
 
         subDir = tempfile.mkdtemp(dir=dataDir)
         destFile = os.path.join(subDir, fits_name)
-        print(f"copied file to {destFile}")
+
         copyfile(fitsFile, destFile)
 
         return config, destFile

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -46,16 +46,22 @@ class MultiComCamIngesterTestCase(asynctest.TestCase):
 
         for x in ingesterConfig["butlers"]:
             butlerConfig = x["butler"]
+            print(f"butlerConfig = {butlerConfig}")
             butlerConfig["badFileDirectory"] = tempfile.mkdtemp()
+            print(f"badFileDirectory for {butlerConfig} is {butlerConfig['badFileDirectory']}")
             butlerConfig["stagingDirectory"] = tempfile.mkdtemp()
+            print(f"stagingDirectory for {butlerConfig} is {butlerConfig['stagingDirectory']}")
             repoDir = tempfile.mkdtemp()
+            print(f"repoDir for {butlerConfig} is {repoDir}")
             butlerConfig["repoDirectory"] = repoDir
             if butlerConfig["class"]["import"] == "lsst.ctrl.oods.gen2ButlerIngester":
                 mapperFileName = os.path.join(repoDir, "_mapper")
                 with open(mapperFileName, 'w') as mapper_file:
                     mapper_file.write("lsst.obs.lsst.comCam.LsstComCamMapper")
 
-        destFile = os.path.join(dataDir, fits_name)
+        subDir = tempfile.mkdtemp(dir=dataDir)
+        destFile = os.path.join(subDir, fits_name)
+        print(f"copied file to {destFile}")
         copyfile(fitsFile, destFile)
 
         return config, destFile


### PR DESCRIPTION
Fix issues if subdirectory exists below root directory, so it retains structure when moving files to bad file directory structure.

Improve unit tests