### PR TITLE
Tickets/dm 33329

### DIFF
--- a/python/lsst/ctrl/oods/cacheCleaner.py
+++ b/python/lsst/ctrl/oods/cacheCleaner.py
@@ -61,7 +61,7 @@ class CacheCleaner(object):
 
         files = self.getAllFilesOlderThan(seconds, self.directories)
         for name in files:
-            LOGGER.info(f"removing file {name}")
+            LOGGER.info("removing file %s", name)
             os.unlink(name)
 
         # remove empty directories
@@ -70,7 +70,7 @@ class CacheCleaner(object):
 
         dirs = self.getAllEmptyDirectoriesOlderThan(seconds, self.directories)
         for name in dirs:
-            LOGGER.info(f"removing directory {name}")
+            LOGGER.info("removing directory %s", name)
             os.rmdir(name)
 
     def getAllFilesOlderThan(self, seconds, directories):

--- a/python/lsst/ctrl/oods/fileIngester.py
+++ b/python/lsst/ctrl/oods/fileIngester.py
@@ -120,7 +120,7 @@ class FileIngester(object):
             handler = self._msg_actions.get(msg_type)
             asyncio.create_task(handler(body))
         else:
-            LOGGER.info(f"unknown message type: {msg_type}")
+            LOGGER.info("unknown message type: %s", msg_type)
 
     def extract_cause(self, e):
         """extract the cause of an exception
@@ -182,7 +182,7 @@ class FileIngester(object):
         os.makedirs(new_dir, exist_ok=True)
         # hard link the file in the staging area
         os.link(filename, new_file)
-        LOGGER.info(f"created link to {new_file}")
+        LOGGER.info("created link to %s", new_file)
 
         return new_file
 
@@ -202,7 +202,7 @@ class FileIngester(object):
                 local_staging_dir = butlerProxy.getStagingDirectory()
                 self.create_link_to_file(filename, local_staging_dir)
         except Exception:
-            LOGGER.info(f"error staging files butler for {filename}")
+            LOGGER.info("error staging files butler for %s", filename)
             return
         # file has been linked to all staging areas;
         # now we unlink the original file.

--- a/python/lsst/ctrl/oods/imageData.py
+++ b/python/lsst/ctrl/oods/imageData.py
@@ -40,14 +40,14 @@ class ImageData:
         try:
             self.info["FILENAME"] = os.path.basename(dataset.path.ospath)
         except Exception as e:
-            LOGGER.info(f"Failed to extract filename for {dataset}: {e}")
+            LOGGER.info("Failed to extract filename for %s: %s", dataset, e)
             return
 
         try:
             refs = dataset.refs
             ref = refs[0]  # OODS only gets a single element in the list
             if ref.dataId.hasRecords() is False:
-                LOGGER.info(f"Failed to extract data for {dataset}; no records")
+                LOGGER.info("Failed to extract data for %s; no records", dataset)
                 return
 
             records = ref.dataId.records
@@ -65,7 +65,7 @@ class ImageData:
                 exposure = records['exposure'].toDict()
                 self.info["OBSID"] = exposure.get("obs_id", "??")
         except Exception as e:
-            LOGGER.info(f"Failed to extract data for {dataset}: {e}")
+            LOGGER.info("Failed to extract data for %s: %s", dataset, e)
 
     def get_info(self):
         """Return the extracted information of the dataset

--- a/tests/etc/ingest_tag_test.yaml
+++ b/tests/etc/ingest_tag_test.yaml
@@ -1,0 +1,45 @@
+defaultInterval: &interval
+    days: 0
+    hours: 0
+    minutes: 0
+    seconds: 0
+
+ingester:
+    FILE_INGEST_REQUEST: CC_FILE_INGEST_REQUEST
+    CONSUME_QUEUE: cc_publish_to_oods
+    PUBLISH_QUEUE: oods_publish_to_cc
+    forwarderStagingDirectory: data
+    butlers:
+        - butler:
+            class:
+                import : lsst.ctrl.oods.gen3ButlerIngester
+                name : Gen3ButlerIngester
+            repoDirectory : repo
+            instrument: lsst.obs.lsst.LsstComCam
+            badFileDirectory: /tmp/bad
+            stagingDirectory: /tmp/staging
+            collections:
+                - LSSTComCam/raw/all
+            scanInterval:
+                <<: *interval
+                seconds: 20
+            filesOlderThan:
+                <<: *interval
+                seconds: 5
+    batchSize: 20
+    scanInterval:
+        <<: *interval
+        seconds: 15 
+
+cacheCleaner:
+    directories:
+        - repo/raw
+    scanInterval:
+        <<: *interval
+        seconds: 30
+    filesOlderThan:
+        <<: *interval
+        days: 30 
+    directoriesEmptyForMoreThan:
+        <<: *interval
+        days: 1

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -21,8 +21,6 @@
 
 import asynctest
 import asyncio
-import logging
-import lsst.log as lsstlog
 import os
 import tempfile
 from pathlib import PurePath
@@ -264,7 +262,3 @@ class MemoryTester(lsst.utils.tests.MemoryTestCase):
 
 def setup_module(module):
     lsst.utils.tests.init()
-    lsstlog.usePythonLogging()
-
-    F = '%(levelname) -10s %(asctime)s.%(msecs)03dZ %(name) -30s %(funcName) -35s %(lineno) -5d: %(message)s'
-    logging.basicConfig(level=logging.INFO, format=(F), datefmt="%Y-%m-%d %H:%M:%S")

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -22,7 +22,6 @@
 import asynctest
 import asyncio
 import logging
-import lsst.log as lsstlog
 import os
 import tempfile
 from pathlib import PurePath
@@ -36,33 +35,43 @@ from lsst.daf.butler.registry import CollectionType
 
 
 class TaggingTestCase(asynctest.TestCase):
-    """Test TAGGED deletion 
+    """Test TAGGED deletion
 
-    This test simulates the OODS asyncio cleanup and a secondary associate (tagging) and
-    disassociate (untagging) of files, to see be sure the OODS cleanup behaves properly:
-    1) When a dataset is TAGGED, will not be deleted, and the OODS cleaup routine bypasses it.
-    2) When a dataset is not TAGGED, it can be deleted, and the OODS cleaup routine removes it.
+    This test simulates the OODS asyncio cleanup and a secondary associate
+    (tagging) and disassociate (untagging) of files, to see be sure the OODS
+    cleanup behaves properly:
 
-    The test simulates this by gathering all ingester asyncio tasks, plus unit test tasks to associate,
-    disassociate and check for a dataset's existance (or non-existance), and an interrupt task. Because
-    the ingester cleanup tasks run at predetermined intervals, the various checks in the unit tests are
-    also set up as asyncio tasks, waiting an appropriate amount of time for the ingest cleanup routines
-    to run. The code below might be a little hard to follow, so here's a description of how the tasks
-    run in this unit test.
+    1) When a dataset is TAGGED, will not be deleted, and the OODS cleaup
+       routine bypasses it.
+    2) When a dataset is not TAGGED, it can be deleted, and the OODS cleaup
+       routine removes it.
+
+    The test simulates this by gathering all ingester asyncio tasks, plus unit
+    test tasks to associate, disassociate and check for a dataset's existance
+    (or non-existance), and an interrupt task. Because the ingester cleanup
+    tasks run at predetermined intervals, the various checks in the unit tests
+    are also set up as asyncio tasks, waiting an appropriate amount of time
+    for the ingest cleanup routines to run. The code below might be a little
+    hard to follow, so here's a description of how the tasks run in this unit
+    test.
 
     1) File ingest runs
-    2) Ingester cleanup runs, and nothing happens because the file hasn't expired yet, and goes to sleep
+    2) Ingester cleanup runs, and nothing happens because the file hasn't
+       expired yet, and goes to sleep
     3) Task to associate the dataset runs, and tags the file, and completes
-    4) Ingester cleanup task runs, finds an expired file, but doesn't deleted it because it's TAGGED, and
-       goes back to sleep
-    5) Task disassociate the dataset runs, and removes the TAGGED designation, and completes
-    6) Task to check that the file runs, affirming it's still on disk, and completes
-    7) Ingester cleanup task runs, finds an expired file, and deletes it, since it's not TAGGED anymore
-       and goes back to sleep
-    8) Task to check that the file runs, affirming it is not longer on disk, and completes
+    4) Ingester cleanup task runs, finds an expired file, but doesn't deleted
+       it because it's TAGGED, and goes back to sleep
+    5) Task disassociate the dataset runs, and removes the TAGGED designation,
+        and completes
+    6) Task to check that the file runs, affirming it's still on disk, and
+       completes
+    7) Ingester cleanup task runs, finds an expired file, and deletes it,
+       since it's not TAGGED anymore and goes back to sleep
+    8) Task to check that the file runs, affirming it is not longer on disk,
+       and completes
     7) Ingester cleanup task runs, finds nothing to do, and goes back to sleep
-    9) Task to interrupt all tasks runs, causes an exception on purpose, which interrupts that gather()
-       causing all tasks to stop.  End of unit test
+    9) Task to interrupt all tasks runs, causes an exception on purpose, which
+       interrupts that gather() causing all tasks to stop.  End of unit test
     """
 
     async def stage(self):
@@ -248,7 +257,7 @@ class TaggingTestCase(asynctest.TestCase):
         # get the dataset
         try:
             results = set(butler.registry.queryDatasets(datasetType=..., collections=self.collections,
-                      where=f"exposure={exposure} and instrument='LSSTComCam'"))
+                          where=f"exposure={exposure} and instrument='LSSTComCam'"))
         except Exception as e:
             logging.info(e)
 


### PR DESCRIPTION
These changes are to add support for NOT deleting tagged datasets when the OODS does it's sweep of file to be purged.

The actual change to the OODS code to do this is relatively small;  the unit test for this is rather complex, and has an explanation for what it does at the beginning of that file.