### PR TITLE
Fix race condition in OODS

### DIFF
--- a/python/lsst/ctrl/oods/fileQueue.py
+++ b/python/lsst/ctrl/oods/fileQueue.py
@@ -65,8 +65,7 @@ class FileQueue(object):
             await asyncio.sleep(self.scanInterval)
 
     async def dequeue_files(self):
-        """Return all of the files retrieved so far
-        """
+        """Return all of the files retrieved so far"""
         # get a list of files, sort it, and clear the fileSet
         async with self.lock:
             file_list = list(self.fileSet)

--- a/python/lsst/ctrl/oods/fileQueue.py
+++ b/python/lsst/ctrl/oods/fileQueue.py
@@ -59,17 +59,17 @@ class FileQueue(object):
         while True:
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 file_list = await loop.run_in_executor(pool, scanner.getAllFiles)
-        
-        async with self.lock:
-            self.fileSet.update(file_list)
-        await asyncio.sleep(self.scanInterval)
+
+            async with self.lock:
+                self.fileSet.update(file_list)
+            await asyncio.sleep(self.scanInterval)
 
     async def dequeue_files(self):
-    """Return all of the files retrieved so far
-    """
+        """Return all of the files retrieved so far
+        """
         # get a list of files, sort it, and clear the fileSet
         async with self.lock:
             file_list = list(self.fileSet)
             file_list.sort()
-            f.fileSet.clear()
+            self.fileSet.clear()
         return file_list

--- a/tests/test_autoingest.py
+++ b/tests/test_autoingest.py
@@ -114,7 +114,8 @@ class AutoIngestTestCase(asynctest.TestCase):
         # create a FileIngester
         ingester = FileIngester(ingesterConfig)
 
-        await ingester.ingest([self.destFile])
+        staged_files = ingester.stageFiles([self.destFile])
+        await ingester.ingest(staged_files)
 
         # check to make sure file was moved from image staging directory
         files = scanner.getAllFiles()
@@ -150,7 +151,8 @@ class AutoIngestTestCase(asynctest.TestCase):
         # check to see that the file is there before ingestion
         self.assertTrue(os.path.exists(self.destFile))
 
-        await ingester.ingest([self.destFile])
+        staged_files = ingester.stageFiles([self.destFile])
+        await ingester.ingest(staged_files)
 
         # make sure image staging area is now empty
         files = scanner.getAllFiles()
@@ -207,13 +209,19 @@ class AutoIngestTestCase(asynctest.TestCase):
 
         ingester = FileIngester(config["ingester"])
 
-        await ingester.ingest([self.destFile])
+        print(f"1 self.destFile = {self.destFile}")
+        staged_files = ingester.stageFiles([self.destFile])
+        print(f"staged_files = {staged_files}")
+        await ingester.ingest(staged_files)
 
         files = scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         name = Utils.strip_prefix(self.destFile, image_staging_dir)
         bad_path = os.path.join(self.badDir, name)
+        print(f"2 self.destFile = {self.destFile}")
+        print(f"image_staging_dir = {image_staging_dir}")
+        print(f"bad_path = {bad_path}")
         self.assertTrue(os.path.exists(bad_path))
 
     async def testRepoExists(self):

--- a/tests/test_autoingest.py
+++ b/tests/test_autoingest.py
@@ -209,9 +209,7 @@ class AutoIngestTestCase(asynctest.TestCase):
 
         ingester = FileIngester(config["ingester"])
 
-        print(f"1 self.destFile = {self.destFile}")
         staged_files = ingester.stageFiles([self.destFile])
-        print(f"staged_files = {staged_files}")
         await ingester.ingest(staged_files)
 
         files = scanner.getAllFiles()
@@ -219,9 +217,6 @@ class AutoIngestTestCase(asynctest.TestCase):
 
         name = Utils.strip_prefix(self.destFile, image_staging_dir)
         bad_path = os.path.join(self.badDir, name)
-        print(f"2 self.destFile = {self.destFile}")
-        print(f"image_staging_dir = {image_staging_dir}")
-        print(f"bad_path = {bad_path}")
         self.assertTrue(os.path.exists(bad_path))
 
     async def testRepoExists(self):

--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -71,7 +71,7 @@ class FileQueueTestCase(asynctest.TestCase):
         # there should be no files to dequeue, because the directory scanner
         # hasn't had a chance to run.
         self.assertEqual(len(file_list), 0)
-        # now, wait a short time to ensure only one file is grabbed (instead of 
+        # now, wait a short time to ensure only one file is grabbed (instead of
         # multiple entries for the same file)
         await asyncio.sleep(3)
         file_list = await fileq.dequeue_files()

--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -31,7 +31,6 @@ class FileQueueTestCase(asynctest.TestCase):
     """Test FileQueue object"""
 
     def setUp(self):
-
         self.tmp_dir = tempfile.mkdtemp()
         fd, self.tmp_file = tempfile.mkstemp()
         with open(self.tmp_file, "w") as f:
@@ -51,6 +50,7 @@ class FileQueueTestCase(asynctest.TestCase):
 
         os.link(self.tmp_file, os.path.join(self.tmp_dir, os.path.basename(self.tmp_file)))
 
+        await asyncio.sleep(1)
         file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 1)
         ret_file = file_list[0]
@@ -68,10 +68,52 @@ class FileQueueTestCase(asynctest.TestCase):
         os.link(self.tmp_file, os.path.join(self.tmp_dir, os.path.basename(self.tmp_file)))
 
         file_list = await fileq.dequeue_files()
+        # there should be no files to dequeue, because the directory scanner
+        # hasn't had a chance to run.
+        self.assertEqual(len(file_list), 0)
+        await asyncio.sleep(3)
+        file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 1)
         ret_file = file_list[0]
 
         self.assertEqual(os.path.basename(self.tmp_file), os.path.basename(ret_file))
-        os.unlink(ret_file)
 
+        os.unlink(ret_file)
+        queue_task.cancel()
+
+    async def testDoubleScan(self):
+        fileq = FileQueue(self.tmp_dir)
+
+        queue_task = asyncio.create_task(fileq.queue_files())
+
+        os.link(self.tmp_file, os.path.join(self.tmp_dir, os.path.basename(self.tmp_file)))
+
+        file_list = await fileq.dequeue_files()
+        self.assertEqual(len(file_list), 0)
+
+        await asyncio.sleep(3)
+        # waited, now there should be 1 file that we can dequeue
+        fd, tmp_file2 = tempfile.mkstemp()
+        with open(tmp_file2, "w") as f:
+            f.write("filequeue test")
+        os.close(fd)
+
+        # create another file, but when we dequeue, there should still only
+        # be one, since we didn't wait.
+        os.link(tmp_file2, os.path.join(self.tmp_dir, os.path.basename(tmp_file2)))
+        file_list = await fileq.dequeue_files()
+        self.assertEqual(len(file_list), 1)
+        print(file_list)
+
+        await asyncio.sleep(3)
+        # we waited, and there should be two files
+        file_list = await fileq.dequeue_files()
+        self.assertEqual(len(file_list), 2)
+        print(file_list)
+
+        ret_file = file_list[0]
+        ret_file2 = file_list[1]
+
+        os.unlink(ret_file)
+        os.unlink(ret_file2)
         queue_task.cancel()

--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -71,6 +71,8 @@ class FileQueueTestCase(asynctest.TestCase):
         # there should be no files to dequeue, because the directory scanner
         # hasn't had a chance to run.
         self.assertEqual(len(file_list), 0)
+        # now, wait a short time to ensure only one file is grabbed (instead of 
+        # multiple entries for the same file)
         await asyncio.sleep(3)
         file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 1)
@@ -103,13 +105,11 @@ class FileQueueTestCase(asynctest.TestCase):
         os.link(tmp_file2, os.path.join(self.tmp_dir, os.path.basename(tmp_file2)))
         file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 1)
-        print(file_list)
 
         await asyncio.sleep(3)
         # we waited, and there should be two files
         file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 2)
-        print(file_list)
 
         ret_file = file_list[0]
         ret_file2 = file_list[1]

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -114,7 +114,8 @@ class Gen3ComCamIngesterTestCase(asynctest.TestCase):
         # create a FileIngester
         ingester = FileIngester(ingesterConfig)
 
-        await ingester.ingest([self.destFile])
+        staged_files = ingester.stageFiles([self.destFile])
+        await ingester.ingest(staged_files)
 
         # check to make sure the file was moved from the staging directory
         files = scanner.getAllFiles()
@@ -149,7 +150,8 @@ class Gen3ComCamIngesterTestCase(asynctest.TestCase):
         # check to see that the file is there before ingestion
         self.assertTrue(os.path.exists(self.destFile))
 
-        await ingester.ingest([self.destFile])
+        staged_files = ingester.stageFiles([self.destFile])
+        await ingester.ingest(staged_files)
 
         # make sure staging area is now empty
         files = scanner.getAllFiles()
@@ -205,7 +207,8 @@ class Gen3ComCamIngesterTestCase(asynctest.TestCase):
 
         ingester = FileIngester(config["ingester"])
 
-        await ingester.ingest([self.destFile])
+        staged_files = ingester.stageFiles([self.destFile])
+        await ingester.ingest(staged_files)
 
         files = scanner.getAllFiles()
         self.assertEqual(len(files), 0)

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -89,7 +89,8 @@ class MultiComCamIngesterTestCase(asynctest.TestCase):
 
         ingester = FileIngester(ingesterConfig)
 
-        await ingester.ingest([destFile])
+        staged_files = ingester.stageFiles([destFile])
+        await ingester.ingest(staged_files)
 
         files = scanner.getAllFiles()
         self.assertEqual(len(files), 0)

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -152,7 +152,8 @@ class TaggingTestCase(asynctest.TestCase):
         self.assertTrue(os.path.exists(self.destFile))
 
         # trigger the ingester
-        await ingester.ingest([self.destFile])
+        staged_files = ingester.stageFiles([self.destFile])
+        await ingester.ingest(staged_files)
 
         # make sure staging area is now empty
         files = scanner.getAllFiles()


### PR DESCRIPTION
It's possible, because of the way the files are queued, to run the directory scan twice before files are ingested.  This usually occurs if there are a lot of images coming in quickly.  While this doesn't  cause problems (if you try to deal with the same file twice, there's an error, but nothing is damaged), it does generate a lot of extra logging messages.  This fix assures the files are dealt with once, so we don't try and do extra work that we don't have to.