### PR TITLE
DM-37110: OODS file queue does not wait

### DIFF
--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -68,13 +68,6 @@ class FileQueueTestCase(asynctest.TestCase):
         os.link(self.tmp_file, os.path.join(self.tmp_dir, os.path.basename(self.tmp_file)))
 
         file_list = await fileq.dequeue_files()
-        # there should be no files to dequeue, because the directory scanner
-        # hasn't had a chance to run.
-        self.assertEqual(len(file_list), 0)
-        # now, wait a short time to ensure only one file is grabbed (instead of
-        # multiple entries for the same file)
-        await asyncio.sleep(3)
-        file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 1)
         ret_file = file_list[0]
 
@@ -90,10 +83,7 @@ class FileQueueTestCase(asynctest.TestCase):
 
         os.link(self.tmp_file, os.path.join(self.tmp_dir, os.path.basename(self.tmp_file)))
 
-        file_list = await fileq.dequeue_files()
-        self.assertEqual(len(file_list), 0)
-
-        await asyncio.sleep(3)
+        await asyncio.sleep(1)
         # waited, now there should be 1 file that we can dequeue
         fd, tmp_file2 = tempfile.mkstemp()
         with open(tmp_file2, "w") as f:
@@ -104,16 +94,19 @@ class FileQueueTestCase(asynctest.TestCase):
         # be one, since we didn't wait.
         os.link(tmp_file2, os.path.join(self.tmp_dir, os.path.basename(tmp_file2)))
         file_list = await fileq.dequeue_files()
-        self.assertEqual(len(file_list), 1)
-
-        await asyncio.sleep(3)
-        # we waited, and there should be two files
-        file_list = await fileq.dequeue_files()
         self.assertEqual(len(file_list), 2)
-
-        ret_file = file_list[0]
+        ret_file1 = file_list[0]
         ret_file2 = file_list[1]
-
-        os.unlink(ret_file)
+        os.unlink(ret_file1)
         os.unlink(ret_file2)
+
+        value = 451
+        try:
+            files = await asyncio.wait_for(fileq.dequeue_files(), timeout=3.0)
+            self.assertEqual(len(files), 0)
+        except Exception:
+            value = 123
+
+        self.assertEqual(value, 123)
+
         queue_task.cancel()

--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -100,13 +100,7 @@ class FileQueueTestCase(asynctest.TestCase):
         os.unlink(ret_file1)
         os.unlink(ret_file2)
 
-        value = 451
-        try:
-            files = await asyncio.wait_for(fileq.dequeue_files(), timeout=3.0)
-            self.assertEqual(len(files), 0)
-        except Exception:
-            value = 123
-
-        self.assertEqual(value, 123)
+        with self.assertRaises(Exception):
+            await asyncio.wait_for(fileq.dequeue_files(), timeout=3.0)
 
         queue_task.cancel()


### PR DESCRIPTION
Fixed an issue  that surfaced when the OODS went live, and the dequeue files method didn't wait properly. 