### PR TITLE
Update unit tests to use unittest.IsolatedAsyncioTestCase

### DIFF
--- a/tests/test_autoingest.py
+++ b/tests/test_autoingest.py
@@ -23,8 +23,8 @@ import asyncio
 import os
 import shutil
 import tempfile
+import unittest
 
-import asynctest
 import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -32,7 +32,7 @@ from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
 
 
-class AutoIngestTestCase(asynctest.TestCase):
+class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
     """Test Gen3 Butler Ingest"""
 
     def createConfig(self, config_name, fits_name):

--- a/tests/test_bad.py
+++ b/tests/test_bad.py
@@ -23,8 +23,8 @@ import asyncio
 import os
 import shutil
 import tempfile
+import unittest
 
-import asynctest
 import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -32,7 +32,7 @@ from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
 
 
-class BadTestCase(asynctest.TestCase):
+class BadTestCase(unittest.IsolatedAsyncioTestCase):
     """Test Gen3 Butler Ingest"""
 
     def createConfig(self, config_name, fits_name):

--- a/tests/test_filequeue.py
+++ b/tests/test_filequeue.py
@@ -22,12 +22,12 @@
 import asyncio
 import os
 import tempfile
+import unittest
 
-import asynctest
 from lsst.ctrl.oods.fileQueue import FileQueue
 
 
-class FileQueueTestCase(asynctest.TestCase):
+class FileQueueTestCase(unittest.IsolatedAsyncioTestCase):
     """Test FileQueue object"""
 
     def setUp(self):

--- a/tests/test_fullasync.py
+++ b/tests/test_fullasync.py
@@ -23,8 +23,8 @@ import asyncio
 import os
 import shutil
 import tempfile
+import unittest
 
-import asynctest
 import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -32,7 +32,7 @@ from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
 
 
-class AsyncIngestTestCase(asynctest.TestCase):
+class AsyncIngestTestCase(unittest.IsolatedAsyncioTestCase):
     """Test full async ingest"""
 
     def createConfig(self, config_name, fits_name):

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -23,8 +23,8 @@ import asyncio
 import os
 import shutil
 import tempfile
+import unittest
 
-import asynctest
 import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -32,7 +32,7 @@ from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
 
 
-class Gen3ComCamIngesterTestCase(asynctest.TestCase):
+class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
     """Test Gen3 Butler Ingest"""
 
     def createConfig(self, config_name, fits_name):

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -21,15 +21,15 @@
 import os
 import shutil
 import tempfile
+import unittest
 
-import asynctest
 import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.ctrl.oods.fileIngester import FileIngester
 
 
-class MultiComCamIngesterTestCase(asynctest.TestCase):
+class MultiComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
     """Test multiple butler ingest"""
 
     def createConfig(self, config_name, fits_name):

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -23,10 +23,11 @@ import asyncio
 import logging
 import os
 import tempfile
+import unittest
+
 from pathlib import PurePath
 from shutil import copyfile
 
-import asynctest
 import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -35,7 +36,7 @@ from lsst.daf.butler import Butler
 from lsst.daf.butler.registry import CollectionType
 
 
-class TaggingTestCase(asynctest.TestCase):
+class TaggingTestCase(unittest.IsolatedAsyncioTestCase):
     """Test TAGGED deletion
 
     This test simulates the OODS asyncio cleanup and a secondary associate

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -24,7 +24,6 @@ import logging
 import os
 import tempfile
 import unittest
-
 from pathlib import PurePath
 from shutil import copyfile
 


### PR DESCRIPTION
This needed to be updated because Python 3.11 removed @asyncio.coroutine, which broke asynctest