### PR TITLE
Remove automatic creation of Butler if it doesn't exist

### DIFF
--- a/python/lsst/ctrl/oods/butlerAttendant.py
+++ b/python/lsst/ctrl/oods/butlerAttendant.py
@@ -57,10 +57,8 @@ class ButlerAttendant:
         self.collections = self.config["collections"]
         self.cleanCollections = self.config.get("cleanCollections", None)
 
-        try:
-            self.butlerConfig = Butler.makeRepo(repo)
-        except FileExistsError:
-            self.butlerConfig = repo
+        LOGGER.info(f"Using Butler repo located at {repo}")
+        self.butlerConfig = repo
 
         try:
             self.butler = self.createButler()

--- a/tests/test_autoingest.py
+++ b/tests/test_autoingest.py
@@ -30,6 +30,7 @@ import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
+from lsst.daf.butler import Butler
 
 
 class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
@@ -80,6 +81,8 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         butlerConfig["stagingDirectory"] = self.stagingDir
 
         self.repoDir = tempfile.mkdtemp()
+        Butler.makeRepo(self.repoDir)
+
         butlerConfig["repoDirectory"] = self.repoDir
 
         # copy the FITS file to it's test location

--- a/tests/test_fullasync.py
+++ b/tests/test_fullasync.py
@@ -30,6 +30,7 @@ import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
+from lsst.daf.butler import Butler
 
 
 class AsyncIngestTestCase(unittest.IsolatedAsyncioTestCase):
@@ -80,6 +81,7 @@ class AsyncIngestTestCase(unittest.IsolatedAsyncioTestCase):
         butlerConfig["stagingDirectory"] = self.stagingDirectory
 
         self.repoDir = tempfile.mkdtemp()
+        Butler.makeRepo(self.repoDir)
         butlerConfig["repoDirectory"] = self.repoDir
 
         # copy the FITS file to it's test location

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -30,6 +30,7 @@ import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.ctrl.oods.fileIngester import FileIngester
 from lsst.ctrl.oods.utils import Utils
+from lsst.daf.butler import Butler
 
 
 class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
@@ -74,6 +75,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         butlerConfig["stagingDirectory"] = self.stagingDirectory
 
         self.repoDir = tempfile.mkdtemp()
+        Butler.makeRepo(self.repoDir)
         butlerConfig["repoDirectory"] = self.repoDir
 
         # copy the FITS file to it's test location

--- a/tests/test_msg.py
+++ b/tests/test_msg.py
@@ -32,6 +32,7 @@ import yaml
 from lsst.ctrl.oods.bucketMessage import BucketMessage
 from lsst.ctrl.oods.msgIngester import MsgIngester
 from lsst.ctrl.oods.msgQueue import MsgQueue
+from lsst.daf.butler import Butler
 
 
 class S3AuxtelIngesterTestCase(unittest.IsolatedAsyncioTestCase):
@@ -63,8 +64,12 @@ class S3AuxtelIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         with open(configFile, "r") as f:
             config = yaml.safe_load(f)
 
+        ingesterConfig = config["ingester"]
+        butlerConfig = ingesterConfig["butlers"][0]["butler"]
+
         self.repoDir = tempfile.mkdtemp()
-        config["repoDirectory"] = self.repoDir
+        Butler.makeRepo(self.repoDir)
+        butlerConfig["repoDirectory"] = self.repoDir
 
         return config
 

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -27,6 +27,7 @@ import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.ctrl.oods.fileIngester import FileIngester
+from lsst.daf.butler import Butler
 
 
 class MultiComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
@@ -56,6 +57,7 @@ class MultiComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
             butlerConfig["stagingDirectory"] = self.stagingRootDir
 
             self.repoDir = tempfile.mkdtemp()
+            Butler.makeRepo(self.repoDir)
 
             butlerConfig["repoDirectory"] = self.repoDir
 

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -120,6 +120,7 @@ class TaggingTestCase(unittest.IsolatedAsyncioTestCase):
         butlerConfig["stagingDirectory"] = self.stagingDirectory
 
         self.repoDir = tempfile.mkdtemp()
+        Butler.makeRepo(self.repoDir)
         butlerConfig["repoDirectory"] = self.repoDir
 
         self.collections = butlerConfig["collections"]


### PR DESCRIPTION
Butler shouldn't be created by OODS;  it should already exist.