### PR TITLE
Remove ThreadPoolExecutor

### DIFF
--- a/python/lsst/ctrl/oods/cacheCleaner.py
+++ b/python/lsst/ctrl/oods/cacheCleaner.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import asyncio
-import concurrent
 import logging
 import os
 import time
@@ -54,16 +53,12 @@ class CacheCleaner(object):
     async def run_tasks(self):
         """Check and clean directories at regular intervals"""
         self.terminate = False
-        loop = asyncio.get_running_loop()
         while True:
             if self.csc:
                 self.csc.log.info("Cleaning %s", self.files_and_directories)
-            try:
-                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    await loop.run_in_executor(pool, self.clean)
-            except Exception as e:
-                if self.csc:
-                    self.csc.log.info("Clean failure: %s", e)
+
+            await self.clean()
+
             if self.csc:
                 self.csc.log.info("done cleaning; waiting %d seconds", self.seconds)
             await asyncio.sleep(self.seconds)
@@ -74,7 +69,7 @@ class CacheCleaner(object):
         """Set flag to stop coroutines"""
         self.terminate = True
 
-    def clean(self):
+    async def clean(self):
         """Remove files older than a given interval, and directories
         that have been empty for a given interval.
         """
@@ -90,8 +85,9 @@ class CacheCleaner(object):
         seconds = TimeInterval.calculateTotalSeconds(self.fileInterval)
         seconds = now - seconds
 
-        files = self.getAllFilesOlderThan(seconds, self.files_and_directories)
+        files = await self.getAllFilesOlderThan(seconds, self.files_and_directories)
         for name in files:
+            await asyncio.sleep(0)
             LOGGER.info("removing %s", name)
             try:
                 os.unlink(name)
@@ -102,10 +98,10 @@ class CacheCleaner(object):
         seconds = TimeInterval.calculateTotalSeconds(self.emptyDirsInterval)
         seconds = now - seconds
 
-        self.clearEmptyDirectories(seconds, self.files_and_directories)
-        self.clearEmptyDirectories(seconds, self.only_empty_directories)
+        await self.clearEmptyDirectories(seconds, self.files_and_directories)
+        await self.clearEmptyDirectories(seconds, self.only_empty_directories)
 
-    def getAllFilesOlderThan(self, seconds, directories):
+    async def getAllFilesOlderThan(self, seconds, directories):
         """Get files in directories older than 'seconds'.
 
         Parameters
@@ -122,11 +118,11 @@ class CacheCleaner(object):
         """
         allFiles = []
         for name in directories:
-            files = self.getFilesOlderThan(seconds, name)
+            files = await self.getFilesOlderThan(seconds, name)
             allFiles.extend(files)
         return allFiles
 
-    def getFilesOlderThan(self, seconds, directory):
+    async def getFilesOlderThan(self, seconds, directory):
         """Get files in one directory older than 'seconds'.
 
         Parameters
@@ -145,6 +141,7 @@ class CacheCleaner(object):
 
         for dirName, subdirs, fileList in os.walk(directory):
             for fname in fileList:
+                await asyncio.sleep(0)
                 fullName = os.path.join(dirName, fname)
                 stat_info = os.stat(fullName)
                 modification_time = stat_info.st_mtime
@@ -152,7 +149,7 @@ class CacheCleaner(object):
                     files.append(fullName)
         return files
 
-    def clearEmptyDirectories(self, seconds, directories):
+    async def clearEmptyDirectories(self, seconds, directories):
         """Get files in one directory older than 'seconds'.
 
         Parameters
@@ -163,11 +160,11 @@ class CacheCleaner(object):
             directories to observe
         """
         for directory in directories:
-            dirs = self.getDirectoriesOlderThan(seconds=seconds, directory=directory)
+            dirs = await self.getDirectoriesOlderThan(seconds=seconds, directory=directory)
             if len(dirs) != 0:
-                self.removeEmptyDirectories(dirs)
+                await self.removeEmptyDirectories(dirs)
 
-    def getDirectoriesOlderThan(self, seconds, directory):
+    async def getDirectoriesOlderThan(self, seconds, directory):
         """Get subdirectories older than "seconds"; Note that
         we get the list of all these directories now, and delete
         later. If we delete in place here, the parent directory modification
@@ -190,6 +187,7 @@ class CacheCleaner(object):
 
         for root, dirs, files in os.walk(directory, topdown=False):
             for name in dirs:
+                await asyncio.sleep(0)
                 full_name = os.path.join(root, name)
                 stat_info = os.stat(full_name)
                 mtime = stat_info.st_mtime
@@ -197,7 +195,7 @@ class CacheCleaner(object):
                     directories.append(full_name)
         return directories
 
-    def removeEmptyDirectories(self, directories):
+    async def removeEmptyDirectories(self, directories):
         """Remove these directories, if they're empty.
 
         Parameters
@@ -206,6 +204,7 @@ class CacheCleaner(object):
             directories to remove, if they're empty
         """
         for directory in sorted(directories, reverse=True):
+            await asyncio.sleep(0)
             if not os.listdir(directory):
                 LOGGER.info("removing %s", directory)
                 try:

--- a/python/lsst/ctrl/oods/directoryScanner.py
+++ b/python/lsst/ctrl/oods/directoryScanner.py
@@ -68,8 +68,8 @@ class DirectoryScanner(object):
         """
         files = []
         for dirName, subdirs, fileList in os.walk(directory):
-            await asyncio.sleep(0.01)
             for fname in fileList:
+                await asyncio.sleep(0)
                 fullName = os.path.join(dirName, fname)
                 files.append(fullName)
         return files

--- a/python/lsst/ctrl/oods/directoryScanner.py
+++ b/python/lsst/ctrl/oods/directoryScanner.py
@@ -18,6 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import asyncio
 import os
 
 
@@ -33,7 +34,7 @@ class DirectoryScanner(object):
     def __init__(self, directories):
         self.directories = directories
 
-    def getAllFiles(self):
+    async def getAllFiles(self):
         """Retrieve all files from a set of directories
 
         Parameters
@@ -48,11 +49,11 @@ class DirectoryScanner(object):
         """
         allFiles = []
         for directory in self.directories:
-            files = self.getFiles(directory)
+            files = await self.getFiles(directory)
             allFiles.extend(files)
         return allFiles
 
-    def getFiles(self, directory):
+    async def getFiles(self, directory):
         """Retrieve all files from a directory
 
         Parameters
@@ -67,6 +68,7 @@ class DirectoryScanner(object):
         """
         files = []
         for dirName, subdirs, fileList in os.walk(directory):
+            await asyncio.sleep(0.01)
             for fname in fileList:
                 fullName = os.path.join(dirName, fname)
                 files.append(fullName)

--- a/python/lsst/ctrl/oods/dm_csc.py
+++ b/python/lsst/ctrl/oods/dm_csc.py
@@ -120,7 +120,7 @@ class DmCsc(BaseCsc):
 
         # if current_state hasn't been set, and the summary_state is STANDBY,
         # we're just starting up, so don't do anything but set the current
-        # state to STANBY
+        # state to STANDBY
         if (self.current_state is None) and (self.summary_state == State.STANDBY):
             self.current_state = State.STANDBY
             self.transitioning_to_fault_evt.clear()

--- a/python/lsst/ctrl/oods/fileIngester.py
+++ b/python/lsst/ctrl/oods/fileIngester.py
@@ -146,7 +146,7 @@ class FileIngester(object):
             for butler in self.butlers:
                 await butler.ingest(butler_file_list[butler])
         except Exception as e:
-            LOGGER.warn("Exception: %s", e)
+            LOGGER.warning("Exception: %s", e)
 
     def run_tasks(self):
         """run tasks to queue files and ingest them"""

--- a/python/lsst/ctrl/oods/fileQueue.py
+++ b/python/lsst/ctrl/oods/fileQueue.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import concurrent
 import logging
 
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
@@ -55,15 +54,12 @@ class FileQueue(object):
         LOGGER.info("Scanning files in %s", self.dir_path)
         scanner = DirectoryScanner([self.dir_path])
 
-        loop = asyncio.get_running_loop()
         # now, add all the currently known files to the queue
         while True:
             if self.csc:
                 self.csc.log.debug("Scanning for new files to ingest")
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                file_list = await loop.run_in_executor(pool, scanner.getAllFiles)
-            if self.csc:
-                self.csc.log.debug("done scanning for new files")
+
+            file_list = await scanner.getAllFiles()
 
             if file_list:
                 async with self.condition:

--- a/python/lsst/ctrl/oods/gen3ButlerIngester.py
+++ b/python/lsst/ctrl/oods/gen3ButlerIngester.py
@@ -30,8 +30,7 @@ from astropy.time import Time, TimeDelta
 from lsst.ctrl.oods.butlerIngester import ButlerIngester
 from lsst.ctrl.oods.imageData import ImageData
 from lsst.ctrl.oods.timeInterval import TimeInterval
-from lsst.daf.butler import Butler
-from lsst.daf.butler.registry import CollectionType
+from lsst.daf.butler import Butler, CollectionType
 from lsst.obs.base.ingest import RawIngestConfig, RawIngestTask
 from lsst.pipe.base import Instrument
 

--- a/python/lsst/ctrl/oods/gen3ButlerIngester.py
+++ b/python/lsst/ctrl/oods/gen3ButlerIngester.py
@@ -21,7 +21,6 @@
 
 import asyncio
 import collections
-import concurrent
 import logging
 import os
 import shutil
@@ -236,12 +235,8 @@ class Gen3ButlerIngester(ButlerIngester):
         """
 
         # Ingest image.
-        try:
-            loop = asyncio.get_running_loop()
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                await loop.run_in_executor(pool, self.task.run, file_list)
-        except Exception as e:
-            LOGGER.info("Ingestion failure: %s", e)
+        await asyncio.sleep(0)
+        self.task.run(file_list)
 
     def getName(self):
         """Return the name of this ingester
@@ -259,18 +254,14 @@ class Gen3ButlerIngester(ButlerIngester):
         while True:
             if self.csc:
                 self.csc.log.info("butler repo cleaning started")
-            try:
-                loop = asyncio.get_running_loop()
-                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    await loop.run_in_executor(pool, self.clean)
-            except Exception as e:
-                if self.csc:
-                    self.csc.log.info("Exception: %s", e)
+
+            await self.clean()
+
             if self.csc:
                 self.csc.log.info("done cleaning butler repo; sleeping for %d seconds", seconds)
             await asyncio.sleep(seconds)
 
-    def clean(self):
+    async def clean(self):
         """Remove all the datasets in the butler that
         were ingested before the configured Interval
         """
@@ -286,8 +277,10 @@ class Gen3ButlerIngester(ButlerIngester):
 
         butler = self.createButler()
 
+        await asyncio.sleep(0)
         butler.registry.refresh()
 
+        await asyncio.sleep(0)
         # get all datasets in these collections
         allCollections = self.collections if self.cleanCollections is None else self.cleanCollections
         all_datasets = set(
@@ -298,10 +291,12 @@ class Gen3ButlerIngester(ButlerIngester):
                 bind={"ref_date": t},
             )
         )
+        await asyncio.sleep(0)
 
         # get all TAGGED collections
         tagged_cols = list(butler.registry.queryCollections(collectionTypes=CollectionType.TAGGED))
 
+        await asyncio.sleep(0)
         # Note: The code below is to get around an issue where passing
         # an empty list as the collections argument to queryDatasets
         # returns all datasets.
@@ -323,6 +318,7 @@ class Gen3ButlerIngester(ButlerIngester):
         # the Butler, and if the URI was available,
         # remove it.
         for x in ref:
+            await asyncio.sleep(0)
             uri = None
             try:
                 uri = butler.getURI(x, collections=x.run)
@@ -336,4 +332,5 @@ class Gen3ButlerIngester(ButlerIngester):
                 except Exception as e:
                     LOGGER.info("error removing %s: %s", uri, e)
 
+        await asyncio.sleep(0)
         butler.pruneDatasets(ref, purge=True, unstore=True)

--- a/python/lsst/ctrl/oods/gen3ButlerIngester.py
+++ b/python/lsst/ctrl/oods/gen3ButlerIngester.py
@@ -234,7 +234,6 @@ class Gen3ButlerIngester(ButlerIngester):
         """
 
         # Ingest image.
-        await asyncio.sleep(0)
         self.task.run(file_list)
 
     def getName(self):
@@ -276,10 +275,8 @@ class Gen3ButlerIngester(ButlerIngester):
 
         butler = self.createButler()
 
-        await asyncio.sleep(0)
         butler.registry.refresh()
 
-        await asyncio.sleep(0)
         # get all datasets in these collections
         allCollections = self.collections if self.cleanCollections is None else self.cleanCollections
         all_datasets = set(

--- a/tests/test_autoingest.py
+++ b/tests/test_autoingest.py
@@ -108,7 +108,7 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create a FileIngester
@@ -118,7 +118,7 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # check to make sure file was moved from image staging directory
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # check to be sure the file didn't land in the "bad file" directory
@@ -135,7 +135,7 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create the file ingester, get all tasks associated with it, and
@@ -155,7 +155,7 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # make sure image staging area is now empty
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # Check to see that the file was ingested.
@@ -204,7 +204,7 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         ingester = FileIngester(config["ingester"])
@@ -212,7 +212,7 @@ class AutoIngestTestCase(unittest.IsolatedAsyncioTestCase):
         staged_files = ingester.stageFiles([self.destFile])
         await ingester.ingest(staged_files)
 
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         name = Utils.strip_prefix(self.destFile, image_staging_dir)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -129,7 +129,7 @@ class CollectionTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create the file ingester, get all tasks associated with it, and
@@ -145,7 +145,7 @@ class CollectionTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # make sure staging area is now empty
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # Check to see that the file was ingested.

--- a/tests/test_fullasync.py
+++ b/tests/test_fullasync.py
@@ -109,7 +109,7 @@ class AsyncIngestTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create a FileIngester
@@ -122,7 +122,7 @@ class AsyncIngestTestCase(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(2)
 
         # check to make sure file was moved from image staging directory
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # check to be sure the file didn't land in the "bad file" directory

--- a/tests/test_gen3.py
+++ b/tests/test_gen3.py
@@ -116,7 +116,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create a FileIngester
@@ -126,7 +126,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # check to make sure the file was moved from the staging directory
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # check to be sure the file didn't land in the "bad file" directory
@@ -143,7 +143,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create the file ingester, get all tasks associated with it, and
@@ -163,7 +163,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # make sure staging area is now empty
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # Check to see that the file was ingested.
@@ -215,7 +215,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 2)
 
         # create the file ingester, get all tasks associated with it, and
@@ -230,7 +230,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # make sure staging area is now empty
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         keyList = list(staged_files.keys())
@@ -289,7 +289,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         ingester = FileIngester(config["ingester"])
@@ -297,7 +297,7 @@ class Gen3ComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         staged_files = ingester.stageFiles([self.destFile])
         await ingester.ingest(staged_files)
 
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         name = Utils.strip_prefix(self.destFile, image_staging_dir)

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -84,7 +84,7 @@ class MultiComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         ingester = FileIngester(ingesterConfig)
@@ -92,7 +92,7 @@ class MultiComCamIngesterTestCase(unittest.IsolatedAsyncioTestCase):
         staged_files = ingester.stageFiles([destFile])
         await ingester.ingest(staged_files)
 
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
 

--- a/tests/test_scandir.py
+++ b/tests/test_scandir.py
@@ -20,19 +20,20 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import tempfile
+import unittest
 
 import lsst.utils.tests
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 
 
-class ScanDirTestCase(lsst.utils.tests.TestCase):
+class ScanDirTestCase(unittest.IsolatedAsyncioTestCase):
     """Test Scanning directory"""
 
-    def testScanDir(self):
+    async def testScanDir(self):
         dirPath = tempfile.mkdtemp()
 
         scanner = DirectoryScanner([dirPath])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
 
         self.assertEqual(len(files), 0)
 
@@ -40,13 +41,13 @@ class ScanDirTestCase(lsst.utils.tests.TestCase):
         (fh2, filename2) = tempfile.mkstemp(dir=dirPath)
         (fh3, filename3) = tempfile.mkstemp(dir=dirPath)
 
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 3)
 
         os.close(fh1)
         os.remove(filename1)
 
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 2)
 
         os.close(fh2)
@@ -54,7 +55,7 @@ class ScanDirTestCase(lsst.utils.tests.TestCase):
         os.close(fh3)
         os.remove(filename3)
 
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         os.rmdir(dirPath)

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -31,8 +31,7 @@ import lsst.utils.tests
 import yaml
 from lsst.ctrl.oods.directoryScanner import DirectoryScanner
 from lsst.ctrl.oods.fileIngester import FileIngester
-from lsst.daf.butler import Butler
-from lsst.daf.butler.registry import CollectionType
+from lsst.daf.butler import Butler, CollectionType
 
 
 class TaggingTestCase(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -135,7 +135,7 @@ class TaggingTestCase(unittest.IsolatedAsyncioTestCase):
         ingesterConfig = config["ingester"]
         image_staging_dir = ingesterConfig["imageStagingDirectory"]
         scanner = DirectoryScanner([image_staging_dir])
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 1)
 
         # create the file ingester, get all tasks associated with it, and
@@ -156,7 +156,7 @@ class TaggingTestCase(unittest.IsolatedAsyncioTestCase):
         await ingester.ingest(staged_files)
 
         # make sure staging area is now empty
-        files = scanner.getAllFiles()
+        files = await scanner.getAllFiles()
         self.assertEqual(len(files), 0)
 
         # Check to see that the file was ingested.


### PR DESCRIPTION
Remove ThreadPoolExecutor from this branch.   This is a back port to fix an issue with the version of the OODS that is currently deployed.