### PR TITLE
Adhere to configuration-specified ingestion limits

### DIFF
--- a/etc/msg_oods.yaml
+++ b/etc/msg_oods.yaml
@@ -29,4 +29,3 @@ ingester:
             scanInterval:
                 <<: *interval
                 seconds: 10
-    batchSize: 20

--- a/etc/oods_example.yaml
+++ b/etc/oods_example.yaml
@@ -5,6 +5,7 @@ defaultInterval: &interval
     seconds: 0
 
 ingester:
+    imageStagingDirectory: /tmp
     butlers:
         - butler:
             collections:

--- a/python/lsst/ctrl/oods/dm_csc.py
+++ b/python/lsst/ctrl/oods/dm_csc.py
@@ -45,10 +45,10 @@ class DmCsc(BaseCsc):
 
     valid_simulation_modes = [0]
     version = __version__
-    LOGGER.info(f"{version=}")
 
     def __init__(self, name, initial_state):
         super().__init__(name, initial_state=initial_state)
+        LOGGER.info(f"OODS version: {self.version}")
 
         self.estimated_timeout = 5.0
 

--- a/python/lsst/ctrl/oods/fileIngester.py
+++ b/python/lsst/ctrl/oods/fileIngester.py
@@ -57,7 +57,7 @@ class FileIngester(object):
         if self.batch_size is None:
             LOGGER.info(f"configuration 'batchSize' not set, defaulting to {DEFAULT_BATCH_SIZE}")
             self.batch_size = DEFAULT_BATCH_SIZE
-        LOGGER.info(f'will ingest in groups of batchSize={self.batch_size}')
+        LOGGER.info(f"will ingest in groups of batchSize={self.batch_size}")
         scanInterval = self.config["scanInterval"]
         seconds = TimeInterval.calculateTotalSeconds(scanInterval)
 

--- a/python/lsst/ctrl/oods/msgIngester.py
+++ b/python/lsst/ctrl/oods/msgIngester.py
@@ -121,8 +121,8 @@ class MsgIngester(object):
         # this is split into two tasks so they can run at slightly different
         # cadences.  We want to gather as many files as we can before we
         # do the ingest
-        task = asyncio.create_task(self.msgQueue.queue_files())
-        self.tasks.append(task)
+        #task = asyncio.create_task(self.msgQueue.queue_files())
+        #self.tasks.append(task)
 
         task = asyncio.create_task(self.dequeue_and_ingest_files())
         self.tasks.append(task)

--- a/python/lsst/ctrl/oods/msgIngester.py
+++ b/python/lsst/ctrl/oods/msgIngester.py
@@ -121,8 +121,6 @@ class MsgIngester(object):
         # this is split into two tasks so they can run at slightly different
         # cadences.  We want to gather as many files as we can before we
         # do the ingest
-        #task = asyncio.create_task(self.msgQueue.queue_files())
-        #self.tasks.append(task)
 
         task = asyncio.create_task(self.dequeue_and_ingest_files())
         self.tasks.append(task)

--- a/python/lsst/ctrl/oods/msgQueue.py
+++ b/python/lsst/ctrl/oods/msgQueue.py
@@ -103,8 +103,16 @@ class MsgQueue(object):
         return message_list
 
     def commit(self, message):
+        """Perform Kafka commit a message
+
+        Parameters
+        ----------
+        message: Kafka message
+            message to commit
+        """
         self.consumer.commit(message=message)
 
     def stop(self):
+        """shut down"""
         self.running = False
         self.consumer.close()

--- a/tests/test_msgqueue.py
+++ b/tests/test_msgqueue.py
@@ -51,7 +51,7 @@ class MsgQueueTestCase(HeartbeatBase):
         mq.consumer.close = MagicMock()
 
         task_list = []
-        task_list.append(asyncio.create_task(mq.queue_files()))
+        #task_list.append(asyncio.create_task(mq.queue_files()))
         task_list.append(asyncio.create_task(self.interrupt_me()))
         msg = await mq.dequeue_messages()
         self.assertEqual(len(msg), 1)

--- a/tests/test_msgqueue.py
+++ b/tests/test_msgqueue.py
@@ -51,7 +51,6 @@ class MsgQueueTestCase(HeartbeatBase):
         mq.consumer.close = MagicMock()
 
         task_list = []
-        #task_list.append(asyncio.create_task(mq.queue_files()))
         task_list.append(asyncio.create_task(self.interrupt_me()))
         msg = await mq.dequeue_messages()
         self.assertEqual(len(msg), 1)


### PR DESCRIPTION
Previously, the ingest batch size was ignored.  Now, this ingestion limit is read from the configuration file and used to limit the number of files that can be ingested at one time.