### PR TITLE
write_data error causes status messages not to be sent

### DIFF
--- a/python/lsst/ctrl/oods/butlerAttendant.py
+++ b/python/lsst/ctrl/oods/butlerAttendant.py
@@ -359,7 +359,7 @@ class ButlerAttendant:
         info["FILENAME"] = "??"
         dataId = dataset.dataId
         info["CAMERA"] = dataId.get("instrument", "??")
-        info["OBSID"] = dataId.get("exposure", "??")
+        info["OBSID"] = str(dataId.get("exposure", "??"))
         info["RAFT"] = self.extract_info_val(dataId, "raft", "R")
         info["SENSOR"] = self.extract_info_val(dataId, "detector", "S")
         return info


### PR DESCRIPTION
An error from `write_data` occurs when the butler callback for ingest failure occurs;  the parameter in the call `self.evt_imageInOODS.set_write` that causes this is `obsid`, which is expected to be a string;  however, the data available at the time that this occurs doesn't yet exist, so we use as close an approximation as possible, which is an `int` when retrieved from the exposure.

This fix forces it to a string.