### PR TITLE
Consolidate dataIds before calling DefineVisitsTask.run()

### DIFF
--- a/python/lsst/ctrl/oods/butlerAttendant.py
+++ b/python/lsst/ctrl/oods/butlerAttendant.py
@@ -388,8 +388,8 @@ class ButlerAttendant:
     def definer_run(self, file_datasets):
         ids = []
         for fds in file_datasets:
-                refs = fds.refs
-                ids.extend([ref.dataId for ref in refs])
+            refs = fds.refs
+            ids.extend([ref.dataId for ref in refs])
         try:
             self.visit_definer.run(ids)
             LOGGER.debug("Defined visits for %s", ids)

--- a/python/lsst/ctrl/oods/butlerAttendant.py
+++ b/python/lsst/ctrl/oods/butlerAttendant.py
@@ -386,11 +386,12 @@ class ButlerAttendant:
         return info
 
     def definer_run(self, file_datasets):
+        ids = []
         for fds in file_datasets:
-            try:
                 refs = fds.refs
-                ids = [ref.dataId for ref in refs]
-                self.visit_definer.run(ids)
-                LOGGER.debug("Defined visits for %s", ids)
-            except Exception as e:
-                LOGGER.exception(e)
+                ids.extend([ref.dataId for ref in refs])
+        try:
+            self.visit_definer.run(ids)
+            LOGGER.debug("Defined visits for %s", ids)
+        except Exception as e:
+            LOGGER.exception(e)


### PR DESCRIPTION
This groups dataIds so that a single call to the DefineVisitsTask.run() method, rather than for each individual file.  This speeds things up since it's acting on a group instead of individual calls.