### PR TITLE
Improve OODS ingest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ Example YAML file for message ingest
                 - atoods
             group_id: ATOODS
             max_messages: 10
+            max_wait_time: 1.0
         butler:
             guider_max_age_seconds: 30
             instrument: lsst.obs.lsst.LsstCam
@@ -162,7 +163,8 @@ The `kafka` section describes
     * ``brokers`` - a list of Kafka brokers the OODS will connect  to for messages
     * ``topics`` - a list of Kafka topics the OODS will listen on
     * ``group_id`` - the group id of this client
-    * ``max_messages`` - the maximum number of messages to wait for before returning.  Note that the OODS may read less messages if it times out before one second.
+    * ``max_messages`` - the maximum number of messages to wait for before returning.  Note that the OODS may read less messages if it times out before ``max_wait_time``.
+    * ``max_wait_time`` - the maximum about of time to wait for before returning, regardless of the number of messages retrieved.
 
 The ``butler`` section describes
     * ``guider_max_age_seconds`` - the number of seconds guiders that haven't been successfully ingested will attempt to be ingested before giving up

--- a/etc/msg_oods.yaml
+++ b/etc/msg_oods.yaml
@@ -12,6 +12,7 @@ message_ingester:
             - atoods
         group_id: ATOODS
         max_messages: 250
+        max_wait_time: 0.5
     butler:
         guider_max_age_seconds: 30
         repo_directory : /tmp/repo

--- a/python/lsst/ctrl/oods/butlerAttendant.py
+++ b/python/lsst/ctrl/oods/butlerAttendant.py
@@ -150,6 +150,7 @@ class ButlerAttendant:
         # then guiders. Wavefront sensors are separated out because they
         # want those ingested asap; guiders are last because a raw has to
         # be ingested before a guider can.
+        LOGGER.info("ingest routine starting")
         await asyncio.sleep(0)
         new_list = file_list
         if self.s3profile:
@@ -174,7 +175,7 @@ class ButlerAttendant:
         for entry in removed_entries:
             LOGGER.info(f"{entry.guider_resource_path} expired; removed from waiting list")
 
-        LOGGER.info("ingest done")
+        LOGGER.info("ingest routine completed")
 
     def on_guider_success(self, datasets):
         """Callback used on successful guider ingest. Used to transmit
@@ -186,6 +187,7 @@ class ButlerAttendant:
             list of Datasets
         """
         for dataset in datasets:
+            LOGGER.info("file %s successfully ingested", dataset.path)
             image_data = ImageData(dataset)
             self.transmit_status(image_data.get_info(), code=0, description="file ingested")
             LOGGER.debug("removing %s from guider list after successful ingestion", dataset.path)
@@ -221,7 +223,9 @@ class ButlerAttendant:
         with ThreadPoolExecutor() as executor:
             try:
                 names = self.guider_list.get_guider_resource_paths()
+                LOGGER.info("about to ingest guiders")
                 await loop.run_in_executor(executor, self._ingest_saved_guiders, names)
+                LOGGER.info("done with ingesting guiders")
             except RuntimeError as re:
                 LOGGER.warning(f"{re}")
             except Exception as e:
@@ -248,9 +252,9 @@ class ButlerAttendant:
         loop = asyncio.get_event_loop()
         with ThreadPoolExecutor() as executor:
             try:
-                LOGGER.debug("about to ingest")
+                LOGGER.info("ingesting ccds starting")
                 await loop.run_in_executor(executor, self.task.run, file_list)
-                LOGGER.debug("done with ingest")
+                LOGGER.info("ingesting ccds completed")
             except RuntimeError as re:
                 LOGGER.info(f"{re}")
             except Exception as e:

--- a/python/lsst/ctrl/oods/butlerAttendant.py
+++ b/python/lsst/ctrl/oods/butlerAttendant.py
@@ -158,32 +158,17 @@ class ButlerAttendant:
 
         entries = [ResourcePath(s) for s in new_list]
 
-        wavefront_patterns = [
-            "R00_SW0",
-            "R00_SW1",
-            "R04_SW0",
-            "R04_SW1",
-            "R40_SW0",
-            "R40_SW1",
-            "R44_SW0",
-            "R44_SW1",
-        ]
-
-        wavefront_sensors, other_entries = self._filter_files(entries, wavefront_patterns)
-
-        if wavefront_sensors:
-            await self._ingest(wavefront_sensors)
-
         guider_pattern = ["_guider.fits"]
-        guiders, raws = self._filter_files(other_entries, guider_pattern)
+        guiders, others = self._filter_files(entries, guider_pattern)
 
-        if raws:
-            await self._ingest(raws)
+        if others:
+            await self._ingest(others)
 
         for guider_resource_path in guiders:
             self.guider_list.append(GuiderEntry(guider_resource_path=guider_resource_path))
 
-        await self.ingest_guiders()
+        if self.guider_list:
+            await self.ingest_guiders()
 
         removed_entries = self.guider_list.purge_old_entries(self.guider_max_age_seconds)
         for entry in removed_entries:

--- a/python/lsst/ctrl/oods/msgIngester.py
+++ b/python/lsst/ctrl/oods/msgIngester.py
@@ -97,12 +97,12 @@ class MsgIngester(object):
         # for each butler, attempt to ingest the requested file,
         # Success or failure is noted in a message description which
         # will send out via a CSC logevent.
-        LOGGER.info("calling ingest")
+        LOGGER.info("message group ingest started")
         try:
             await self.butler.ingest(butler_file_list)
         except Exception as e:
             LOGGER.warning("Exception: %s", e)
-        LOGGER.info("ingest completed")
+        LOGGER.info("message group ingest completed")
 
     def _queue_helper_done_callback(self, task):
         self._helper_done_callback(task, "dequeue task completed")
@@ -156,6 +156,7 @@ class MsgIngester(object):
             message_list = await self.msgQueue.dequeue_messages()
             if message_list is None:
                 return
+            LOGGER.info("%d messages dequeued", len(message_list))
             resources = []
             for m in message_list:
                 if m.error():
@@ -170,6 +171,7 @@ class MsgIngester(object):
                     continue
                 resources.extend(rps)
             if resources:
+                LOGGER.info("%d FITS files to ingest", len(resources))
                 await self.ingest(resources)
 
             # XXX - commit on success, failure, or metadata_failure

--- a/python/lsst/ctrl/oods/msgIngester.py
+++ b/python/lsst/ctrl/oods/msgIngester.py
@@ -57,11 +57,12 @@ class MsgIngester(object):
         topics = kafka_config.topics
 
         max_messages = kafka_config.max_messages
+        max_wait_time = kafka_config.max_wait_time
 
         LOGGER.info("listening to brokers %s", brokers)
         LOGGER.info("listening on topics %s", topics)
         LOGGER.info("max_messages set to %d", max_messages)
-        self.msgQueue = MsgQueue(brokers, group_id, topics, max_messages)
+        self.msgQueue = MsgQueue(brokers, group_id, topics, max_messages, max_wait_time)
 
         self.butler = ButlerProxy(self.config, self.csc)
 

--- a/python/lsst/ctrl/oods/msgQueue.py
+++ b/python/lsst/ctrl/oods/msgQueue.py
@@ -42,11 +42,11 @@ class MsgQueue(object):
 
     Parameters
     ----------
-    brokers : `dict`
-        configuration dictionary for a consumer
+    brokers : `list[str]`
+        A list of Kafka brokers
     group_id : `str`
         Kafka group to join
-    topics : `list`
+    topics : `list[str]`
         Kafka topics to listen on
     max_messages : `int`
         Maximum number of messages to grab at once
@@ -110,7 +110,7 @@ class MsgQueue(object):
         ----------
         config : `dict`
             Kafka configuration for consumer
-        topics : `list`
+        topics : `list[str]`
             List of Kafka topics to subscribe to
         """
         self.consumer = Consumer(config)

--- a/python/lsst/ctrl/oods/msgQueue.py
+++ b/python/lsst/ctrl/oods/msgQueue.py
@@ -51,7 +51,7 @@ class MsgQueue(object):
     max_messages : `int`
         Maximum number of messages to grab at once
     max_wait_time : `float`
-        Maximum amount of time in seconds to wait before returning from consumer request
+        Maximum amount of time in seconds to wait for consumer read
     """
 
     def __init__(self, brokers, group_id, topics, max_messages, max_wait_time):

--- a/python/lsst/ctrl/oods/msgQueue.py
+++ b/python/lsst/ctrl/oods/msgQueue.py
@@ -38,21 +38,28 @@ MECHANISM_KEY = "LSST_KAFKA_SECURITY_MECHANISM"
 
 
 class MsgQueue(object):
-    """Report on new messages
+    """Read messages from Kafka
 
     Parameters
     ----------
-    config: `dict`
+    brokers : `dict`
         configuration dictionary for a consumer
-    topics: `list`
-        The topics to listen on
+    group_id : `str`
+        Kafka group to join
+    topics : `list`
+        Kafka topics to listen on
+    max_messages : `int`
+        Maximum number of messages to grab at once
+    max_wait_time : `float`
+        Maximum amount of time in seconds to wait before returning from consumer request
     """
 
-    def __init__(self, brokers, group_id, topics, max_messages):
+    def __init__(self, brokers, group_id, topics, max_messages, max_wait_time):
         self.brokers = brokers
         self.group_id = group_id
         self.topics = topics
         self.max_messages = max_messages
+        self.max_wait_time = max_wait_time
 
         self.msgList = list()
         self.condition = asyncio.Condition()
@@ -97,7 +104,15 @@ class MsgQueue(object):
         self.running = True
 
     def createConsumer(self, config, topics):
-        """Create a Kafka Consumer"""
+        """Create a Kafka Consumer
+
+        Parameters
+        ----------
+        config : `dict`
+            Kafka configuration for consumer
+        topics : `list`
+            List of Kafka topics to subscribe to
+        """
         self.consumer = Consumer(config)
         self.consumer.subscribe(topics)
         LOGGER.info("subscribed")
@@ -107,7 +122,7 @@ class MsgQueue(object):
         LOGGER.debug("getting more messages")
         while self.running:
             try:
-                m_list = self.consumer.consume(num_messages=self.max_messages, timeout=1.0)
+                m_list = self.consumer.consume(num_messages=self.max_messages, timeout=self.max_wait_time)
             except Exception as e:
                 LOGGER.exception(e)
                 raise e
@@ -116,8 +131,14 @@ class MsgQueue(object):
             LOGGER.debug("message(s) received")
             return m_list
 
-    async def dequeue_messages(self):
-        """Retrieve messages"""
+    async def dequeue_messages(self) -> list:
+        """Retrieve messages
+
+        Returns
+        -------
+        ret : `list`
+            list of messages read from Kafka consumer
+        """
         try:
             loop = asyncio.get_running_loop()
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
@@ -127,7 +148,7 @@ class MsgQueue(object):
             LOGGER.info("get messages task cancelled")
 
     def commit(self, message):
-        """Perform Kafka commit a message
+        """Perform Kafka commit on a message
 
         Parameters
         ----------

--- a/python/lsst/ctrl/oods/oods_config.py
+++ b/python/lsst/ctrl/oods/oods_config.py
@@ -106,6 +106,7 @@ class KafkaConfig(BaseModel):
     topics: list[str]
     group_id: str
     max_messages: int
+    max_wait_time: float = 1.0
 
 
 class MessageIngesterConfig(BaseModel):

--- a/tests/etc/ingest_auxtel_s3.yaml
+++ b/tests/etc/ingest_auxtel_s3.yaml
@@ -6,12 +6,13 @@ default_interval: &interval
 
 message_ingester:
     kafka:
-       brokers:
-           - kafka:9092
-       topics:
-           - atoods
-       group_id: ATOODS
-       max_messages: 10
+        brokers:
+            - kafka:9092
+        topics:
+            - atoods
+        group_id: ATOODS
+        max_messages: 10
+        max_wait_time: 1.0
     butler:
         guider_max_age_seconds: 30
         repo_directory: repo

--- a/tests/test_msgqueue.py
+++ b/tests/test_msgqueue.py
@@ -44,7 +44,7 @@ class MsgQueueTestCase(HeartbeatBase):
         with open(dataFile, "r") as f:
             message = f.read()
 
-        mq = MsgQueue(brokers, group_id, topics, max_messages)
+        mq = MsgQueue(brokers, group_id, topics, max_messages, 1.0)
         mq.consumer = MagicMock()
         mq.consumer.consume = MagicMock(return_value=[message])
         mq.consumer.commit = MagicMock()


### PR DESCRIPTION
Combine wavefront and raw ingest, because doing them separately doesn't buy us anything, and in fact, extends overall ingest time.  

Add a parameter, `max_wait_time`, to configure the maximum amount of time to wait for a group of Kafka messages before timeout out (if the maximum number of files isn't read yet).